### PR TITLE
Error Handling UPDATE

### DIFF
--- a/script.js
+++ b/script.js
@@ -12,7 +12,9 @@ function fetchDataAndUpdateUI() {
             updateUI(data);
         })
         .catch(error => {
+            // Handle error and display a message to the user
             console.error('Error fetching data:', error);
+            document.getElementById("output").innerHTML = "<p>Oops! Couldn't fetch a joke right now.</p>";
         });
 }
 
@@ -28,6 +30,7 @@ function updateUI(data) {
     // Update the content of the output div with the HTML content
     document.getElementById("output").innerHTML = htmlContent;
 }
+
 // Add click event listener for the Save button
 document.getElementById("saveButton").addEventListener("click", function () {
     const outputDiv = document.getElementById("output");
@@ -45,8 +48,7 @@ document.getElementById("saveButton").addEventListener("click", function () {
     canvas.width = estimatedWidth;
     canvas.height = estimatedHeight;
   
-    // RenderING the HTML content onto the canvas using the library html2canvas
-    
+    // Rendering the HTML content onto the canvas using the library html2canvas
     html2canvas(outputDiv, { canvas }).then(function (canvas) {
       // Convert canvas to data URL
       const dataURL = canvas.toDataURL("image/png");
@@ -57,4 +59,4 @@ document.getElementById("saveButton").addEventListener("click", function () {
       link.download = "random_joke.png";
       link.click();
     });
-  });
+});


### PR DESCRIPTION
Error handling before update: 
The error is only logged to the browser console (console.error), but no feedback is provided to the user when the joke fetch fails. The user interface remains unchanged, leaving the user without any indication that something went wrong.

Error handling after update:
In addition to logging the error to the console, this snippet also updates the UI by displaying a user-friendly message ("Oops! Couldn't fetch a joke right now.") in the #output div. This provides visual feedback to the user, letting them know that the joke could not be fetched due to an error.
